### PR TITLE
add domain decomposition and random flow examples

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -59,9 +59,9 @@ version = "1.0.0"
 
 [[CategoricalArrays]]
 deps = ["Compat", "DataAPI", "Future", "JSON", "Missings", "Printf", "Reexport", "Unicode"]
-git-tree-sha1 = "45101c4d0df3946acb6e9bfcfd3a8c32abbd421b"
+git-tree-sha1 = "2473560b9c7cb18f98c3c926af0dc7bedccfc7ab"
 uuid = "324d7699-5711-5eae-9e2f-1d82baa6b597"
-version = "0.7.1"
+version = "0.7.2"
 
 [[ColorTypes]]
 deps = ["FixedPointNumbers", "Random"]
@@ -130,10 +130,10 @@ deps = ["Mmap"]
 uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 
 [[DiffEqBase]]
-deps = ["ArrayInterface", "Compat", "DiffEqDiffTools", "Distributed", "DocStringExtensions", "FunctionWrappers", "IterativeSolvers", "IteratorInterfaceExtensions", "LinearAlgebra", "MuladdMacro", "Parameters", "Printf", "RecipesBase", "RecursiveArrayTools", "RecursiveFactorization", "Requires", "Roots", "SparseArrays", "StaticArrays", "Statistics", "SuiteSparse", "TableTraits", "TreeViews"]
-git-tree-sha1 = "05a10ee594cc6a810b3c0e337b6b61405f387ef3"
+deps = ["ArrayInterface", "Compat", "DataStructures", "DiffEqDiffTools", "Distributed", "DocStringExtensions", "FunctionWrappers", "IterativeSolvers", "IteratorInterfaceExtensions", "LinearAlgebra", "MuladdMacro", "Parameters", "Printf", "RecipesBase", "RecursiveArrayTools", "RecursiveFactorization", "Requires", "Roots", "SparseArrays", "StaticArrays", "Statistics", "SuiteSparse", "TableTraits", "TreeViews"]
+git-tree-sha1 = "7baac860c5042935c5da8095170aa9907652e3c0"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
-version = "6.4.2"
+version = "6.5.0"
 
 [[DiffEqCallbacks]]
 deps = ["DataStructures", "DiffEqBase", "ForwardDiff", "LinearAlgebra", "NLsolve", "OrdinaryDiffEq", "RecipesBase", "RecursiveArrayTools", "StaticArrays"]
@@ -412,9 +412,9 @@ version = "1.1.0"
 
 [[OrdinaryDiffEq]]
 deps = ["ArrayInterface", "DataStructures", "DiffEqBase", "DiffEqDiffTools", "ExponentialUtilities", "ForwardDiff", "GenericSVD", "LinearAlgebra", "Logging", "MacroTools", "MuladdMacro", "Parameters", "RecursiveArrayTools", "Reexport", "SparseArrays", "SparseDiffTools", "StaticArrays"]
-git-tree-sha1 = "d7be23057a7bc3cc7574633108dd4c744c94539a"
+git-tree-sha1 = "d8a0e3ac59d4f2cb250bbc390306c7aa3e699403"
 uuid = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
-version = "5.20.1"
+version = "5.23.0"
 
 [[Parameters]]
 deps = ["OrderedCollections"]
@@ -591,9 +591,9 @@ version = "1.5.0"
 
 [[StochasticDiffEq]]
 deps = ["ArrayInterface", "DataStructures", "DiffEqBase", "DiffEqDiffTools", "DiffEqNoiseProcess", "FillArrays", "ForwardDiff", "LinearAlgebra", "Logging", "MuladdMacro", "NLsolve", "Parameters", "Random", "RandomNumbers", "RecursiveArrayTools", "Reexport", "SparseArrays", "SparseDiffTools", "StaticArrays"]
-git-tree-sha1 = "241afdb61a9da201c70dd7a6d92a91f11140ba75"
+git-tree-sha1 = "8e9542cf36b7d186d1cda09d192d55c3ad39875b"
 uuid = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
-version = "6.12.0"
+version = "6.13.0"
 
 [[SuiteSparse]]
 deps = ["Libdl", "LinearAlgebra", "SparseArrays"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IndividualDisplacements"
 uuid = "b92f0c32-5b7e-11e9-1d7b-238b2da8b0e6"
 authors = ["gaelforget <gforget@mit.edu>"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/examples/global_ocean_fleet.jl
+++ b/examples/global_ocean_fleet.jl
@@ -19,7 +19,7 @@
 
 # ## 1. import software
 
-using IndividualDisplacements, MeshArrays, DifferentialEquations, Plots, Statistics
+using IndividualDisplacements, MeshArrays, DifferentialEquations, Plots, Statistics, Dierckx
 p=dirname(pathof(IndividualDisplacements))
 include(joinpath(p,"PlotIndDisp.jl"))
 
@@ -115,14 +115,35 @@ prob = ODEProblem(comp_vel,uInitS,tspan,uvetc)
 sol = solve(prob,Tsit5(),reltol=1e-4,abstol=1e-4)
 size(sol)
 
-# ## 4. Store trajectories in a `DataFrame` and plot
+# ## 4. Plot trajectories
+#
+# - Copy `sol` to a `DataFrame`
 
 ID=collect(1:size(sol,2))*ones(1,size(sol,3))
-lon=mod.(sol[1,:,:],360)
-lat=mod.(sol[2,:,:],180)
-df = DataFrame(ID=Int.(ID[:]), lon=lon[:], lat=lat[:])
+i=mod.(sol[1,:,:],360)
+j=mod.(sol[2,:,:],180)
+df = DataFrame(ID=Int.(ID[:]), i=i[:], j=j[:])
 size(df)
 
-PyPlot.figure(); PlotBasic(df,size(sol,2),90.0)
+# - Map i,j position to lon,lat coordinates
+
+# +
+x=0.0:1.0:361.0
+y=[GridVariables["XC"][1,1][1,1].-1.0 ; GridVariables["XC"][1,1][:,1] ; GridVariables["XC"][1,1][end,1].+1.0]
+spl_lon = Spline1D(x,y)
+
+x=0.0:1.0:179.0
+y=[GridVariables["YC"][1,1][1,1].-1.0 ; GridVariables["YC"][1,1][1,:] ; GridVariables["YC"][1,1][1,end].+1.0]
+spl_lat = Spline1D(x,y)
+
+df[:,:lon].=spl_lon(df[:,:i])
+df[:,:lat].=spl_lat(df[:,:j])
+
+show(df)
+# -
+# - Plot trajectories
+
+PyPlot.figure(); PlotMapProj(df,3000)
+
 
 

--- a/examples/global_ocean_fleet.jl
+++ b/examples/global_ocean_fleet.jl
@@ -136,8 +136,8 @@ x=0.0:1.0:179.0
 y=[GridVariables["YC"][1,1][1,1].-1.0 ; GridVariables["YC"][1,1][1,:] ; GridVariables["YC"][1,1][1,end].+1.0]
 spl_lat = Spline1D(x,y)
 
-df[:,:lon].=spl_lon(df[:,:i])
-df[:,:lat].=spl_lat(df[:,:j])
+df.lon=spl_lon(df[:,:i])
+df.lat=spl_lat(df[:,:j])
 
 show(df)
 # -

--- a/examples/random_flow_dpdo.jl
+++ b/examples/random_flow_dpdo.jl
@@ -23,18 +23,14 @@ using IndividualDisplacements, MeshArrays, DifferentialEquations, Plots, Statist
 p=dirname(pathof(IndividualDisplacements))
 include(joinpath(p,"PlotIndDisp.jl"))
 
-# ## 2. Read gridded variables as `MeshArray`s
+# ## 2. Define gridded variables as `MeshArray`s
 
-# _Note:_ `myread` function deals with tiled files from `flt_example/`; should be able to use it via `gcmgrid`...
-#
 # Put grid variables in a dictionary.
 
 # +
 GridVariables=GridOfOnes("dpdo",16,20)
 (Rini,Rend,DXCsm,DYCsm)=MeshArrays.demo2(GridVariables)
 
-#GridVariables=GridOfOnes("ll",1,40)
-#(Rini,Rend,DXCsm,DYCsm)=MeshArrays.demo2(GridVariables)
 heatmap(Rend[1])
 # -
 
@@ -62,7 +58,8 @@ uvt = Dict("u0" => u0, "u1" => u1, "v0" => v0, "v1" => v1, "t0" => t0, "t1" => t
 # +
 uvetc=merge(uvt,GridVariables);
 
-#this would need to be exchanged too...
+# _Note:_ in general case, mskW & mskS would need to be exchanged ...
+
 mskW=fill(1.0,u)
 mskS=fill(1.0,v)
 
@@ -101,8 +98,6 @@ for i in eachindex(ii)
     comp_vel(du,[ii[i];jj[i];fIndex[i]],uvetc,0.0)
     tmpu[i],tmpv[i],tmpf[i]=du
 end
-#tmp=zeros(10,1)
-#for comp_vel(du,[180.1;40.1],uvetc,0.0)
 Plots.plot(tmpu)
 Plots.plot!(tmpv)
 # -
@@ -111,7 +106,6 @@ Plots.plot!(tmpv)
 
 using DifferentialEquations
 tspan = (0.0,nSteps*dt)
-#prob = ODEProblem(get_vel,uInit,tspan,tmp)
 prob = ODEProblem(comp_vel,uInit,tspan,uvetc)
 sol_one = solve(prob,Tsit5(),reltol=1e-8,abstol=1e-8)
 size(sol_one)
@@ -121,10 +115,7 @@ du=fill(0.0,size(uInitS));
 comp_vel(du,uInitS,uvetc,0.0)
 du
 
-# **Note how the size of sol (ie nb of steps) depends on initial location:**
-
 # +
-#ii1=1:40; ii2=1:40;
 ii1=0.5:0.5:20; ii2=0.5:0.5:20; ii3=[2.0 4.0 5.0 7.0 10.0 12.0 13.0 15.0];
 
 n1=length(ii1); n2=length(ii2); n3=length(ii3);
@@ -147,7 +138,6 @@ size(sol)
 ID=collect(1:size(sol,2))*ones(1,size(sol,3))
 lon=sol[1,:,:]+20.0*mod.(sol[3,:,:].-1,4)
 lat=sol[2,:,:]+20.0*floor.((sol[3,:,:].-1)/4)
-#lat=mod.(sol[2,:,:],40)
 fIndex=sol[3,:,:]
 df = DataFrame(ID=Int.(ID[:]), lon=lon[:], lat=lat[:], fIndex=fIndex[:])
 size(df)

--- a/examples/random_flow_exch.jl
+++ b/examples/random_flow_exch.jl
@@ -30,34 +30,21 @@ include(joinpath(p,"PlotIndDisp.jl"))
 # Put grid variables in a dictionary.
 
 # +
-#GridVariables=GridOfOnes("dpdo",1,40)
-#(Rini,Rend,DXCsm,DYCsm)=MeshArrays.demo2(GridVariables)
-
-GridVariables=GridOfOnes("ll",1,40)
+GridVariables=GridOfOnes("dpdo",1,40)
 (Rini,Rend,DXCsm,DYCsm)=MeshArrays.demo2(GridVariables)
+
+#GridVariables=GridOfOnes("ll",1,40)
+#(Rini,Rend,DXCsm,DYCsm)=MeshArrays.demo2(GridVariables)
 heatmap(Rend[1])
 # -
 
 # Derive velocity fields using Rend as a scalar potential (**later: streamfunction...**)
 
 (u,v)=gradient(Rend,GridVariables)
+u=u./GridVariables["DXC"]#normalization to grid units
+v=v./GridVariables["DYC"]
 (u,v)=exchange(u,v,1)
 u0=-v; u1=-v; v0=u; v1=u;
-
-# +
-dxc,dyc=exchange(GridVariables["DXC"],GridVariables["DYC"])
-dxc=abs.(dxc)
-dyc=abs.(dyc)
-
-#hack to fix ll grid case
-dxc[findall(dxc.<1.0)]=1.0
-dyc[findall(dyc.<1.0)]=1.0
-
-u0=u0./dxc#normalization to grid units
-u1=u1./dxc
-v0=v0./dyc
-v1=v1./dyc
-# -
 
 # Put velocity fields and time range in a dictionary.
 
@@ -145,7 +132,7 @@ uInitS=Array{Float64,2}(undef,(3,n1*n2))
 for i1 in eachindex(ii1); for i2 in eachindex(ii2);
         i=i1+(i2-1)*n1
         uInitS[1,i]=ii1[i1]-0.5
-        uInitS[2,i]=ii2[i2]-0.5       
+        uInitS[2,i]=ii2[i2]-0.5
         uInitS[3,i]=1.0
 end; end;
 du=fill(0.0,size(uInitS));
@@ -165,5 +152,3 @@ size(df)
 
 nn=minimum([5000 size(du,2)])
 PyPlot.figure(); PlotBasic(df,nn,20.0)
-
-

--- a/examples/random_flow_exch.jl
+++ b/examples/random_flow_exch.jl
@@ -30,7 +30,7 @@ include(joinpath(p,"PlotIndDisp.jl"))
 # Put grid variables in a dictionary.
 
 # +
-GridVariables=GridOfOnes("dpdo",1,40)
+GridVariables=GridOfOnes("dpdo",16,20)
 (Rini,Rend,DXCsm,DYCsm)=MeshArrays.demo2(GridVariables)
 
 #GridVariables=GridOfOnes("ll",1,40)
@@ -125,7 +125,7 @@ du
 
 # +
 #ii1=1:40; ii2=1:40;
-ii1=0.25:0.25:40; ii2=0.25:0.25:40;
+ii1=0.25:0.25:20; ii2=0.25:0.25:20;
 
 n1=length(ii1); n2=length(ii2);
 uInitS=Array{Float64,2}(undef,(3,n1*n2))
@@ -145,10 +145,12 @@ sol = solve(prob,Tsit5(),reltol=1e-5,abstol=1e-5)
 size(sol)
 
 ID=collect(1:size(sol,2))*ones(1,size(sol,3))
-lon=mod.(sol[1,:,:],40)
-lat=mod.(sol[2,:,:],40)
-df = DataFrame(ID=Int.(ID[:]), lon=lon[:], lat=lat[:])
+lon=sol[1,:,:]+20.0*mod.(sol[3,:,:].-1,4)
+lat=sol[2,:,:]+20.0*floor.((sol[3,:,:].-1)/4)
+#lat=mod.(sol[2,:,:],40)
+fIndex=sol[3,:,:]
+df = DataFrame(ID=Int.(ID[:]), lon=lon[:], lat=lat[:], fIndex=fIndex[:])
 size(df)
 
 nn=minimum([5000 size(du,2)])
-PyPlot.figure(); PlotBasic(df,nn,20.0)
+PyPlot.figure(); PlotBasic(df,nn,10.0)

--- a/examples/random_flow_exch.jl
+++ b/examples/random_flow_exch.jl
@@ -1,0 +1,169 @@
+# ---
+# jupyter:
+#   jupytext:
+#     formats: ipynb,jl:light
+#     text_representation:
+#       extension: .jl
+#       format_name: light
+#       format_version: '1.4'
+#       jupytext_version: 1.2.4
+#   kernelspec:
+#     display_name: Julia 1.1.0
+#     language: julia
+#     name: julia-1.1
+# ---
+
+# # This notebook
+#
+# _Notes:_ For documentation see <https://gaelforget.github.io/MeshArrays.jl/stable/>, <https://docs.juliadiffeq.org/latest/solvers/ode_solve.html> and <https://en.wikipedia.org/wiki/Displacement_(vector)>
+
+# ## 1. import software
+
+using IndividualDisplacements, MeshArrays, DifferentialEquations, Plots, Statistics
+p=dirname(pathof(IndividualDisplacements))
+include(joinpath(p,"PlotIndDisp.jl"))
+
+# ## 2. Read gridded variables as `MeshArray`s
+
+# _Note:_ `myread` function deals with tiled files from `flt_example/`; should be able to use it via `gcmgrid`...
+#
+# Put grid variables in a dictionary.
+
+# +
+#GridVariables=GridOfOnes("dpdo",1,40)
+#(Rini,Rend,DXCsm,DYCsm)=MeshArrays.demo2(GridVariables)
+
+GridVariables=GridOfOnes("ll",1,40)
+(Rini,Rend,DXCsm,DYCsm)=MeshArrays.demo2(GridVariables)
+heatmap(Rend[1])
+# -
+
+# Derive velocity fields using Rend as a scalar potential (**later: streamfunction...**)
+
+(u,v)=gradient(Rend,GridVariables)
+(u,v)=exchange(u,v,1)
+u0=-v; u1=-v; v0=u; v1=u;
+
+# +
+dxc,dyc=exchange(GridVariables["DXC"],GridVariables["DYC"])
+dxc=abs.(dxc)
+dyc=abs.(dyc)
+
+#hack to fix ll grid case
+dxc[findall(dxc.<1.0)]=1.0
+dyc[findall(dyc.<1.0)]=1.0
+
+u0=u0./dxc#normalization to grid units
+u1=u1./dxc
+v0=v0./dyc
+v1=v1./dyc
+# -
+
+# Put velocity fields and time range in a dictionary.
+
+# +
+t0=0.0 #approximation / simplification
+t1=100.0
+dt=0.1
+nSteps=(t1-t0)/dt
+
+uvt = Dict("u0" => u0, "u1" => u1, "v0" => v0, "v1" => v1, "t0" => t0, "t1" => t1, "dt" => dt) ;
+# -
+
+# Merge the two dictionaries and add masks
+
+# +
+uvetc=merge(uvt,GridVariables);
+
+#this would need to be exchanged too...
+mskW=fill(1.0,u)
+mskS=fill(1.0,v)
+
+msk=Dict("mskW" => mskW, "mskS" => mskS)
+
+uvetc=merge(uvetc,msk);
+# -
+
+# ## 3. Visualize  gridded variables
+
+heatmap(mskW[1,1].*u0[1,1],title="U at the start")
+
+# ## 4. Recompute displacements from gridded flow fields
+
+# Initialize individual locations and define method aliases.
+
+# +
+uInit=[20.0,20.0,1.0]
+du=fill(0.0,3);
+
+comp_vel=IndividualDisplacements.VelComp!
+get_vel=IndividualDisplacements.VelCopy
+# -
+
+# Inspect how `comp_vel` behaves.
+
+# +
+ii=uInit[1]-3:0.1:uInit[1]+3
+jj=uInit[2]-3:0.1:uInit[2]+3
+fIndex=ones(size(jj))
+
+tmpu=zeros(size(ii))
+tmpv=zeros(size(ii))
+tmpf=zeros(size(ii))
+for i in eachindex(ii)
+    comp_vel(du,[ii[i];jj[i];fIndex[i]],uvetc,0.0)
+    tmpu[i],tmpv[i],tmpf[i]=du
+end
+#tmp=zeros(10,1)
+#for comp_vel(du,[180.1;40.1],uvetc,0.0)
+Plots.plot(tmpu)
+Plots.plot!(tmpv)
+# -
+
+# ## 5. Solve through time using `DifferentialEquations.jl`
+
+using DifferentialEquations
+tspan = (0.0,nSteps*dt)
+#prob = ODEProblem(get_vel,uInit,tspan,tmp)
+prob = ODEProblem(comp_vel,uInit,tspan,uvetc)
+sol_one = solve(prob,Tsit5(),reltol=1e-8,abstol=1e-8)
+size(sol_one)
+
+uInitS=[uInit uInit]
+du=fill(0.0,size(uInitS));
+comp_vel(du,uInitS,uvetc,0.0)
+du
+
+# **Note how the size of sol (ie nb of steps) depends on initial location:**
+
+# +
+#ii1=1:40; ii2=1:40;
+ii1=0.25:0.25:40; ii2=0.25:0.25:40;
+
+n1=length(ii1); n2=length(ii2);
+uInitS=Array{Float64,2}(undef,(3,n1*n2))
+for i1 in eachindex(ii1); for i2 in eachindex(ii2);
+        i=i1+(i2-1)*n1
+        uInitS[1,i]=ii1[i1]-0.5
+        uInitS[2,i]=ii2[i2]-0.5       
+        uInitS[3,i]=1.0
+end; end;
+du=fill(0.0,size(uInitS));
+comp_vel(du,uInitS,uvetc,0.0)
+du
+# -
+
+prob = ODEProblem(comp_vel,uInitS,tspan,uvetc)
+sol = solve(prob,Tsit5(),reltol=1e-5,abstol=1e-5)
+size(sol)
+
+ID=collect(1:size(sol,2))*ones(1,size(sol,3))
+lon=mod.(sol[1,:,:],40)
+lat=mod.(sol[2,:,:],40)
+df = DataFrame(ID=Int.(ID[:]), lon=lon[:], lat=lat[:])
+size(df)
+
+nn=minimum([5000 size(du,2)])
+PyPlot.figure(); PlotBasic(df,nn,20.0)
+
+

--- a/examples/random_flow_exch.jl
+++ b/examples/random_flow_exch.jl
@@ -50,7 +50,7 @@ u0=-v; u1=-v; v0=u; v1=u;
 
 # +
 t0=0.0 #approximation / simplification
-t1=100.0
+t1=200.0
 dt=0.1
 nSteps=(t1-t0)/dt
 
@@ -125,16 +125,16 @@ du
 
 # +
 #ii1=1:40; ii2=1:40;
-ii1=0.25:0.25:20; ii2=0.25:0.25:20;
+ii1=0.5:0.5:20; ii2=0.5:0.5:20; ii3=[2.0 4.0 5.0 7.0 10.0 12.0 13.0 15.0];
 
-n1=length(ii1); n2=length(ii2);
-uInitS=Array{Float64,2}(undef,(3,n1*n2))
-for i1 in eachindex(ii1); for i2 in eachindex(ii2);
-        i=i1+(i2-1)*n1
-        uInitS[1,i]=ii1[i1]-0.5
-        uInitS[2,i]=ii2[i2]-0.5
-        uInitS[3,i]=1.0
-end; end;
+n1=length(ii1); n2=length(ii2); n3=length(ii3);
+uInitS=Array{Float64,2}(undef,(3,n3*n1*n2))
+for i1 in eachindex(ii1); for i2 in eachindex(ii2); for i3 in eachindex(ii3);
+        i=i1+(i2-1)*n1+(i3-1)*n1*n2
+        uInitS[1,i]=ii1[i1]
+        uInitS[2,i]=ii2[i2]
+        uInitS[3,i]=ii3[i3]
+end; end; end;
 du=fill(0.0,size(uInitS));
 comp_vel(du,uInitS,uvetc,0.0)
 du

--- a/examples/random_flow_fleet.jl
+++ b/examples/random_flow_fleet.jl
@@ -41,7 +41,7 @@ heatmap(Rend[1])
 # Derive velocity fields using Rend as a scalar potential (**later: streamfunction...**)
 
 (u,v)=gradient(Rend,GridVariables)
-u0=u; u1=u; v0=v; v1=v;
+u0=-v; u1=-v; v0=u; v1=u;
 
 # Put velocity fields and time range in a dictionary.
 
@@ -120,10 +120,8 @@ du
 # **Note how the size of sol (ie nb of steps) depends on initial location:**
 
 # +
-#ii1=1:10:80; ii2=1:10:42; #->sol is (2, 40, 40065)
-#ii1=30:37; ii2=16:20; #->sol is (2, 40, 9674)
-#ii1=10:17; ii2=16:20; #->sol is (2, 40, 51709)
-ii1=5:35; ii2=5:35; #->sol is (2, 40, 51709)
+#ii1=1:40; ii2=1:40;
+ii1=0.25:0.25:40; ii2=0.25:0.25:40;
 
 n1=length(ii1); n2=length(ii2);
 uInitS=Array{Float64,2}(undef,(2,n1*n2))
@@ -138,7 +136,7 @@ du
 # -
 
 prob = ODEProblem(comp_vel,uInitS,tspan,uvetc)
-sol = solve(prob,Tsit5(),reltol=1e-8,abstol=1e-8)
+sol = solve(prob,Tsit5(),reltol=1e-5,abstol=1e-5)
 size(sol)
 
 ID=collect(1:size(sol,2))*ones(1,size(sol,3))
@@ -147,6 +145,7 @@ lat=mod.(sol[2,:,:],40)
 df = DataFrame(ID=Int.(ID[:]), lon=lon[:], lat=lat[:])
 size(df)
 
-PyPlot.figure(); PlotBasic(df,size(sol,2),20.0)
+nn=minimum([5000 size(du,2)])
+PyPlot.figure(); PlotBasic(df,nn,20.0)
 
 

--- a/examples/random_flow_fleet.jl
+++ b/examples/random_flow_fleet.jl
@@ -23,18 +23,13 @@ using IndividualDisplacements, MeshArrays, DifferentialEquations, Plots, Statist
 p=dirname(pathof(IndividualDisplacements))
 include(joinpath(p,"PlotIndDisp.jl"))
 
-# ## 2. Read gridded variables as `MeshArray`s
+# ## 2. Define gridded variables as `MeshArray`s
 
-# _Note:_ `myread` function deals with tiled files from `flt_example/`; should be able to use it via `gcmgrid`...
-#
 # Put grid variables in a dictionary.
-
-# +
-#GridVariables=GridOfOnes("dpdo",16,20)
-#(Rini,Rend,DXCsm,DYCsm)=MeshArrays.demo2(GridVariables)
 
 GridVariables=GridOfOnes("ll",1,40)
 (Rini,Rend,DXCsm,DYCsm)=MeshArrays.demo2(GridVariables)
+
 heatmap(Rend[1])
 # -
 
@@ -85,7 +80,6 @@ uInit=[20.0,20.0]
 du=fill(0.0,2);
 
 comp_vel=IndividualDisplacements.VelComp
-get_vel=IndividualDisplacements.VelCopy
 # -
 
 # Inspect how `comp_vel` behaves.
@@ -98,8 +92,6 @@ for i in eachindex(ii)
     comp_vel(du,[ii[i];jj[i]],uvetc,0.0)
     tmpu[i],tmpv[i]=du
 end
-#tmp=zeros(10,1)
-#for comp_vel(du,[180.1;40.1],uvetc,0.0)
 Plots.plot(tmpu)
 Plots.plot!(tmpv)
 
@@ -107,7 +99,6 @@ Plots.plot!(tmpv)
 
 using DifferentialEquations
 tspan = (0.0,nSteps*dt)
-#prob = ODEProblem(get_vel,uInit,tspan,tmp)
 prob = ODEProblem(comp_vel,uInit,tspan,uvetc)
 sol_one = solve(prob,Tsit5(),reltol=1e-8,abstol=1e-8)
 size(sol_one)
@@ -117,18 +108,15 @@ du=fill(0.0,size(uInitS));
 comp_vel(du,uInitS,uvetc,0.0)
 du
 
-# **Note how the size of sol (ie nb of steps) depends on initial location:**
-
 # +
-#ii1=1:40; ii2=1:40;
 ii1=0.25:0.25:40; ii2=0.25:0.25:40;
 
 n1=length(ii1); n2=length(ii2);
 uInitS=Array{Float64,2}(undef,(2,n1*n2))
 for i1 in eachindex(ii1); for i2 in eachindex(ii2);
         i=i1+(i2-1)*n1
-        uInitS[1,i]=ii1[i1]-0.5
-        uInitS[2,i]=ii2[i2]-0.5       
+        uInitS[1,i]=ii1[i1]
+        uInitS[2,i]=ii2[i2]
 end; end;
 du=fill(0.0,size(uInitS));
 comp_vel(du,uInitS,uvetc,0.0)
@@ -147,5 +135,3 @@ size(df)
 
 nn=minimum([5000 size(du,2)])
 PyPlot.figure(); PlotBasic(df,nn,20.0)
-
-

--- a/examples/random_flow_fleet.jl
+++ b/examples/random_flow_fleet.jl
@@ -1,0 +1,152 @@
+# ---
+# jupyter:
+#   jupytext:
+#     formats: ipynb,jl:light
+#     text_representation:
+#       extension: .jl
+#       format_name: light
+#       format_version: '1.4'
+#       jupytext_version: 1.2.4
+#   kernelspec:
+#     display_name: Julia 1.1.0
+#     language: julia
+#     name: julia-1.1
+# ---
+
+# # This notebook
+#
+# _Notes:_ For documentation see <https://gaelforget.github.io/MeshArrays.jl/stable/>, <https://docs.juliadiffeq.org/latest/solvers/ode_solve.html> and <https://en.wikipedia.org/wiki/Displacement_(vector)>
+
+# ## 1. import software
+
+using IndividualDisplacements, MeshArrays, DifferentialEquations, Plots, Statistics
+p=dirname(pathof(IndividualDisplacements))
+include(joinpath(p,"PlotIndDisp.jl"))
+
+# ## 2. Read gridded variables as `MeshArray`s
+
+# _Note:_ `myread` function deals with tiled files from `flt_example/`; should be able to use it via `gcmgrid`...
+#
+# Put grid variables in a dictionary.
+
+# +
+#GridVariables=GridOfOnes("dpdo",16,20)
+#(Rini,Rend,DXCsm,DYCsm)=MeshArrays.demo2(GridVariables)
+
+GridVariables=GridOfOnes("ll",1,40)
+(Rini,Rend,DXCsm,DYCsm)=MeshArrays.demo2(GridVariables)
+heatmap(Rend[1])
+# -
+
+# Derive velocity fields using Rend as a scalar potential (**later: streamfunction...**)
+
+(u,v)=gradient(Rend,GridVariables)
+u0=u; u1=u; v0=v; v1=v;
+
+# Put velocity fields and time range in a dictionary.
+
+# +
+t0=0.0 #approximation / simplification
+t1=100.0
+dt=0.1
+nSteps=(t1-t0)/dt
+
+u0=u0./GridVariables["DXC"]#normalization to grid units
+u1=u1./GridVariables["DXC"]
+v0=v0./GridVariables["DYC"]
+v1=v1./GridVariables["DYC"]
+
+uvt = Dict("u0" => u0, "u1" => u1, "v0" => v0, "v1" => v1, "t0" => t0, "t1" => t1, "dt" => dt) ;
+# -
+
+# Merge the two dictionaries and add masks
+
+# +
+uvetc=merge(uvt,GridVariables);
+
+mskW=fill(1.0,u)
+mskS=fill(1.0,v)
+
+msk=Dict("mskW" => mskW, "mskS" => mskS)
+
+uvetc=merge(uvetc,msk);
+# -
+
+# ## 3. Visualize  gridded variables
+
+heatmap(mskW[1,1].*u0[1,1],title="U at the start")
+
+# ## 4. Recompute displacements from gridded flow fields
+
+# Initialize individual locations and define method aliases.
+
+# +
+uInit=[20.0,20.0]
+du=fill(0.0,2);
+
+comp_vel=IndividualDisplacements.VelComp
+get_vel=IndividualDisplacements.VelCopy
+# -
+
+# Inspect how `comp_vel` behaves.
+
+ii=uInit[1]-3:0.1:uInit[1]+3
+jj=uInit[2]-3:0.1:uInit[2]+3
+tmpu=zeros(size(ii))
+tmpv=zeros(size(ii))
+for i in eachindex(ii)
+    comp_vel(du,[ii[i];jj[i]],uvetc,0.0)
+    tmpu[i],tmpv[i]=du
+end
+#tmp=zeros(10,1)
+#for comp_vel(du,[180.1;40.1],uvetc,0.0)
+Plots.plot(tmpu)
+Plots.plot!(tmpv)
+
+# ## 5. Solve through time using `DifferentialEquations.jl`
+
+using DifferentialEquations
+tspan = (0.0,nSteps*dt)
+#prob = ODEProblem(get_vel,uInit,tspan,tmp)
+prob = ODEProblem(comp_vel,uInit,tspan,uvetc)
+sol_one = solve(prob,Tsit5(),reltol=1e-8,abstol=1e-8)
+size(sol_one)
+
+uInitS=[uInit uInit]
+du=fill(0.0,size(uInitS));
+comp_vel(du,uInitS,uvetc,0.0)
+du
+
+# **Note how the size of sol (ie nb of steps) depends on initial location:**
+
+# +
+#ii1=1:10:80; ii2=1:10:42; #->sol is (2, 40, 40065)
+#ii1=30:37; ii2=16:20; #->sol is (2, 40, 9674)
+#ii1=10:17; ii2=16:20; #->sol is (2, 40, 51709)
+ii1=5:35; ii2=5:35; #->sol is (2, 40, 51709)
+
+n1=length(ii1); n2=length(ii2);
+uInitS=Array{Float64,2}(undef,(2,n1*n2))
+for i1 in eachindex(ii1); for i2 in eachindex(ii2);
+        i=i1+(i2-1)*n1
+        uInitS[1,i]=ii1[i1]-0.5
+        uInitS[2,i]=ii2[i2]-0.5       
+end; end;
+du=fill(0.0,size(uInitS));
+comp_vel(du,uInitS,uvetc,0.0)
+du
+# -
+
+prob = ODEProblem(comp_vel,uInitS,tspan,uvetc)
+sol = solve(prob,Tsit5(),reltol=1e-8,abstol=1e-8)
+size(sol)
+
+ID=collect(1:size(sol,2))*ones(1,size(sol,3))
+lon=mod.(sol[1,:,:],40)
+lat=mod.(sol[2,:,:],40)
+df = DataFrame(ID=Int.(ID[:]), lon=lon[:], lat=lat[:])
+size(df)
+
+PyPlot.figure(); PlotBasic(df,size(sol,2),20.0)
+
+

--- a/src/IndividualDisplacements.jl
+++ b/src/IndividualDisplacements.jl
@@ -7,7 +7,7 @@ include("ReadIndDisp.jl")
 include("VelocityIndDisp.jl")
 include("examples.jl")
 
-export VelComp, VelCopy, ReadGriddedFields, ReadDisplacements
+export VelComp, VelComp!, VelCopy, ReadGriddedFields, ReadDisplacements
 #export PlotBasic, PlotMapProj
 
 end # module


### PR DESCRIPTION
- `src/VelocityIndDisp.jl` :  add `VelComp!` that updates `x,y` and `fIndex` which is included in `du` and `u` as a third (last) element; also add `NeighborTileIndices_dpdo` that `VelComp!` uses to update `fIndex`
- `src/IndividualDisplacements.jl` : export `VelComp!`
- `examples/random_flow_fleet.jl` (new) uses a randomly generated streamfunction and a `GridOfOnes` generated grid (`ll`)
- `random_flow_dpdo.jl` (new) is the same but uses `VelComp!` instead of `VelComp` and a doubly periodic domain with 16 tiles (`dpdo`)
- `global_ocean_fleet.jl` : diagnoze lon,lat from i,j using `Dierckx.jl` & use `cartopy` for improved plotting